### PR TITLE
Add a check before the getSvgPath to avoid clipping the entire element

### DIFF
--- a/packages/squircle-element-react/src/index.tsx
+++ b/packages/squircle-element-react/src/index.tsx
@@ -46,6 +46,7 @@ function Squircle<E extends React.ElementType = "div">({
   const actualHeight = h ?? height;
 
   const path = useMemo(() => {
+    if (actualWidth === 0 || actualHeight === 0) return "";
     return getSvgPath({
       width: actualWidth,
       height: actualHeight,


### PR DESCRIPTION
This PR introduces a pre-check before the `getSvgPath` call. This means we'll show the "non-squircle" element until we get the actual element size. This won't influence components with `width`/`height` or `defaultWidth`/`defaultHeight`.

### Before:

https://github.com/user-attachments/assets/aacec9ae-046f-44d8-9f0d-2379132ffe7e

### After:


https://github.com/user-attachments/assets/0c1791b0-fab1-4a8d-8f72-0bc63d0d33ef

