### PR TITLE
Fix ESM module format extension in squircle-js/react package

### DIFF
--- a/.changeset/plenty-colts-take.md
+++ b/.changeset/plenty-colts-take.md
@@ -1,0 +1,5 @@
+---
+"@squircle-js/react": patch
+---
+
+Fix ESM module format in build output to resolve Vite import errors. Ensures .mjs files are generated correctly by tsup for ESM modules.

--- a/packages/squircle-element-react/package.json
+++ b/packages/squircle-element-react/package.json
@@ -7,8 +7,8 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsup src/index.tsx --format cjs,esm --dts --external react",
-    "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "clean": "rm -rf .turbo dist node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",

--- a/packages/squircle-element-react/tsup.config.js
+++ b/packages/squircle-element-react/tsup.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    entry: ["src/index.tsx"],
+    format: ["cjs", "esm"],
+    dts: true,
+    external: ["react"],
+    outExtension({ format }) {
+        return {
+            js: format === "esm" ? ".mjs" : ".js",
+        }
+    },
+})


### PR DESCRIPTION
## Description
This PR addresses an issue with the ESM module format in the `@squircle-js/react` package that's causing build errors in Vite projects (as reported in [issue #30](https://github.com/bring-shrubbery/squircle-js/issues/30)). Currently, the package.json specifies `index.mjs` as the module entry point, but tsup is generating `index.js` files instead, causing a mismatch between the declared exports and the actual build artifacts.

## Problem
The problem stems from a known issue in tsup (see [tsup#1132](https://github.com/egoist/tsup/issues/1132)) where `.mjs` files are being renamed to `.js` after the build process is complete, even when configured to generate ESM format.

Users attempting to import the package in Vite are encountering this error:
```
[vite] Internal server error: Failed to resolve entry for package "@squircle-js/react". The package may have incorrect main/module/exports specified in its package.json
```

The current output structure is:
```
dist/
  ├── index.cjs
  ├── index.d.cts
  ├── index.d.ts
  └── index.js
```

But package.json expects:
```json
{
  "main": "dist/index.js",
  "module": "dist/index.mjs",
  "types": "dist/index.d.ts"
}
```

## Solution
I've added a tsup configuration file that explicitly sets the correct output extension for ESM modules using the `outExtension` option. This ensures that the build process generates `.mjs` files for ESM format that match the declared exports in package.json.

## Changes
- Added a `tsup.config.js` file to control build output formats
- Configured tsup to generate `.mjs` extensions for ESM modules
- Maintained backward compatibility with existing imports

## Testing
I've verified that the build now correctly generates both `.js` (CJS) and `.mjs` (ESM) files in the dist directory, matching what's declared in the package.json.

This fix ensures that bundlers like Vite and other tools that rely on the `module` field in package.json will be able to correctly import the ESM version of the package.