### PR TITLE
fix: repair Node native ESM/CJS resolution

### DIFF
--- a/.changeset/fix-esm-cjs-exports.md
+++ b/.changeset/fix-esm-cjs-exports.md
@@ -1,0 +1,17 @@
+---
+"@squircle-js/react": patch
+"@squircle-js/vue": patch
+"@squircle-js/solid": patch
+---
+
+Unify and repair the exports contract across `@squircle-js/react`, `@squircle-js/vue`, and `@squircle-js/solid`.
+
+Both `@squircle-js/react@1.3.0` and `@squircle-js/vue@0.1.0` shipped CJS content in a `dist/index.js` file while declaring `"type": "module"` in their package. Under that declaration Node parses every `.js` file as ESM, so any consumer that reached the package via Node's native loader (Next.js `serverExternalPackages`, `node --input-type=module`, Bun, Node 22+ `require(esm)`) hit `ReferenceError: module is not defined` on `import()` or a silently empty object on `require()`. Bundlers were unaffected because they prefer the non-standard `module` field pointing at `.mjs`.
+
+Fixes:
+
+- `@squircle-js/react`: `tsup` now emits CJS as `.cjs`; `package.json` gains an `exports` field with `import` / `require` conditions each carrying their own `types` (`.d.ts` / `.d.cts`); `main` points at `./dist/index.cjs`; `files: ["dist"]` matches the sibling packages.
+- `@squircle-js/vue`: Vite now emits CJS as `index.cjs`; `package.json` `main` and the `exports.require` condition point at `./dist/index.cjs`; the `exports` shape is restructured to the same per-condition form as `@squircle-js/react` and `@squircle-js/solid`.
+- `@squircle-js/solid`: no functional change (its CJS output was already `.cjs` and its ESM output is real ESM); adds a top-level `default` fallback in `exports` to match the other packages.
+
+After this change, all three packages resolve consistently via Node native `import()`, Node `require()` (Node 22+ `require(esm)` interop), and every bundler that honors `exports`.

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -16,7 +16,8 @@
       "require": {
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
-      }
+      },
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/squircle-element-react/package.json
+++ b/packages/squircle-element-react/package.json
@@ -3,9 +3,25 @@
   "version": "1.3.0",
   "license": "MIT",
   "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "default": "./dist/index.mjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",

--- a/packages/squircle-element-react/tsup.config.js
+++ b/packages/squircle-element-react/tsup.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   external: ["react"],
   outExtension({ format }) {
     return {
-      js: format === "esm" ? ".mjs" : ".js",
+      js: format === "esm" ? ".mjs" : ".cjs",
     };
   },
 });

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -3,14 +3,19 @@
   "version": "0.1.0",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      },
       "default": "./dist/index.mjs"
     }
   },

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     lib: {
       entry: resolve(import.meta.dirname, "src/index.ts"),
       name: "SquircleJsVue",
-      fileName: (format) => (format === "es" ? "index.mjs" : "index.js"),
+      fileName: (format) => (format === "es" ? "index.mjs" : "index.cjs"),
       formats: ["es", "cjs"],
     },
     rollupOptions: {


### PR DESCRIPTION
Hey! 👋 Thanks for maintaining these packages — really enjoying using them.

Ran into a packaging issue when consuming `@squircle-js/react` from a Next.js app and wanted to send a fix over. Turned out `@squircle-js/vue` had the same shape, so I bundled both plus a small consistency tweak to `@squircle-js/solid` into one PR.

## Problem

Both `@squircle-js/react` and `@squircle-js/vue` declare `"type": "module"` but ship CJS content in `dist/index.js`. Node parses every `.js` under `type: module` as ESM, so consumers using Node's native loader (Next.js `serverExternalPackages`, Bun, `node --input-type=module`) crash with `ReferenceError: module is not defined`. Bundlers were unaffected because they prefer the `module` field — which is why this slipped past #31.

Repro:
```bash
node -e "import('@squircle-js/react').then(m => console.log(Object.keys(m)))"

Fix

- Emit CJS as .cjs (react via tsup, vue via Vite)
- Add exports with import / require conditions, each carrying its own types
- Point main at ./dist/index.cjs
- Apply the same shape to @squircle-js/solid for consistency (no functional change)
- @squircle-js/svelte untouched (already ESM-only)

Changeset included — patch bump for react / vue / solid.
```
