### PR TITLE
feat(react): add Base UI useRender integration

### DIFF
--- a/.changeset/calm-squircles-render.md
+++ b/.changeset/calm-squircles-render.md
@@ -1,0 +1,5 @@
+---
+"@squircle-js/react": minor
+---
+
+Add a Base UI integration at `@squircle-js/react/base` using the `render` prop.

--- a/.changeset/fix-esm-cjs-exports.md
+++ b/.changeset/fix-esm-cjs-exports.md
@@ -1,0 +1,17 @@
+---
+"@squircle-js/react": patch
+"@squircle-js/vue": patch
+"@squircle-js/solid": patch
+---
+
+Unify and repair the exports contract across `@squircle-js/react`, `@squircle-js/vue`, and `@squircle-js/solid`.
+
+Both `@squircle-js/react@1.3.0` and `@squircle-js/vue@0.1.0` shipped CJS content in a `dist/index.js` file while declaring `"type": "module"` in their package. Under that declaration Node parses every `.js` file as ESM, so any consumer that reached the package via Node's native loader (Next.js `serverExternalPackages`, `node --input-type=module`, Bun, Node 22+ `require(esm)`) hit `ReferenceError: module is not defined` on `import()` or a silently empty object on `require()`. Bundlers were unaffected because they prefer the non-standard `module` field pointing at `.mjs`.
+
+Fixes:
+
+- `@squircle-js/react`: `tsup` now emits CJS as `.cjs`; `package.json` gains an `exports` field with `import` / `require` conditions each carrying their own `types` (`.d.ts` / `.d.cts`); `main` points at `./dist/index.cjs`; `files: ["dist"]` matches the sibling packages.
+- `@squircle-js/vue`: Vite now emits CJS as `index.cjs`; `package.json` `main` and the `exports.require` condition point at `./dist/index.cjs`; the `exports` shape is restructured to the same per-condition form as `@squircle-js/react` and `@squircle-js/solid`.
+- `@squircle-js/solid`: no functional change (its CJS output was already `.cjs` and its ESM output is real ESM); adds a top-level `default` fallback in `exports` to match the other packages.
+
+After this change, all three packages resolve consistently via Node native `import()`, Node `require()` (Node 22+ `require(esm)` interop), and every bundler that honors `exports`.

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -16,7 +16,8 @@
       "require": {
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
-      }
+      },
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/squircle-element-react/package.json
+++ b/packages/squircle-element-react/package.json
@@ -3,9 +3,25 @@
   "version": "1.3.0",
   "license": "MIT",
   "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "default": "./dist/index.mjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",

--- a/packages/squircle-element-react/package.json
+++ b/packages/squircle-element-react/package.json
@@ -17,6 +17,17 @@
         "default": "./dist/index.cjs"
       },
       "default": "./dist/index.mjs"
+    },
+    "./base": {
+      "import": {
+        "types": "./dist/base.d.ts",
+        "default": "./dist/base.mjs"
+      },
+      "require": {
+        "types": "./dist/base.d.cts",
+        "default": "./dist/base.cjs"
+      },
+      "default": "./dist/base.mjs"
     }
   },
   "files": [
@@ -33,6 +44,7 @@
     "figma-squircle": "1.1.0"
   },
   "devDependencies": {
+    "@base-ui/react": "^1.6.0",
     "@squircle-js/tsconfig": "workspace:*",
     "@swc/core": "^1.11.5",
     "@types/react": "catalog:react",
@@ -41,7 +53,13 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
+    "@base-ui/react": "^1.6.0",
     "react": "^16.8 || ^17 || ^18 || ^19"
+  },
+  "peerDependenciesMeta": {
+    "@base-ui/react": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",

--- a/packages/squircle-element-react/src/base.tsx
+++ b/packages/squircle-element-react/src/base.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRender } from "@base-ui/react/use-render";
+import { forwardRef } from "react";
+
+import { type SquircleOptions, useSquircle } from "./use-squircle";
+
+type SquircleProps = SquircleOptions &
+  Omit<useRender.ComponentProps<"div">, keyof SquircleOptions>;
+
+const Squircle = forwardRef<HTMLDivElement, SquircleProps>(function Squircle(
+  {
+    cornerRadius,
+    cornerSmoothing = 0.6,
+    render,
+    style,
+    width,
+    height,
+    defaultWidth,
+    defaultHeight,
+    ...props
+  },
+  forwardedRef
+) {
+  const { ref, elementProps } = useSquircle({
+    cornerRadius,
+    cornerSmoothing,
+    style,
+    width,
+    height,
+    defaultWidth,
+    defaultHeight,
+  });
+
+  return useRender({
+    defaultTagName: "div",
+    render,
+    ref: [forwardedRef, ref],
+    props: { ...props, ...elementProps },
+  });
+});
+
+export { Squircle, type SquircleProps };

--- a/packages/squircle-element-react/src/index.tsx
+++ b/packages/squircle-element-react/src/index.tsx
@@ -1,25 +1,15 @@
 "use client";
 
 import { Slot } from "@radix-ui/react-slot";
-import { getSvgPath } from "figma-squircle";
 import type * as React from "react";
-import { useMemo } from "react";
 
-import { useElementSize } from "./use-element-size";
+import { type SquircleOptions, useSquircle } from "./use-squircle";
 
 export { SquircleNoScript } from "./no-js";
 
-interface SquircleProps {
-  cornerSmoothing?: number;
-  cornerRadius?: number;
+interface SquircleProps extends SquircleOptions {
   asChild?: boolean;
   children?: React.ReactNode;
-
-  width?: number;
-  height?: number;
-
-  defaultWidth?: number;
-  defaultHeight?: number;
 }
 
 function Squircle<E extends React.ElementType = "div">({
@@ -37,40 +27,17 @@ function Squircle<E extends React.ElementType = "div">({
   const Component = asChild ? Slot : "div";
 
   // Note: If you need to pass ref, wrap this component in another, and style to full-width/height.
-  const [ref, { width, height }] = useElementSize<HTMLDivElement>({
+  const { ref, elementProps } = useSquircle({
+    cornerRadius,
+    cornerSmoothing,
+    style,
+    width: w,
+    height: h,
     defaultWidth,
     defaultHeight,
   });
 
-  const actualWidth = w ?? width;
-  const actualHeight = h ?? height;
-
-  const path = useMemo(() => {
-    if (actualWidth === 0 || actualHeight === 0) {
-      return "";
-    }
-    return getSvgPath({
-      width: actualWidth,
-      height: actualHeight,
-      cornerRadius,
-      cornerSmoothing,
-    });
-  }, [actualWidth, actualHeight, cornerRadius, cornerSmoothing]);
-
-  return (
-    <Component
-      {...props}
-      data-squircle={cornerRadius}
-      ref={ref}
-      style={{
-        ...style,
-        borderRadius: cornerRadius,
-        width: w ?? defaultWidth,
-        height: h ?? defaultHeight,
-        clipPath: `path('${path}')`,
-      }}
-    />
-  );
+  return <Component {...props} {...elementProps} ref={ref} />;
 }
 
 export * from "./StaticSquircle";

--- a/packages/squircle-element-react/src/use-squircle.ts
+++ b/packages/squircle-element-react/src/use-squircle.ts
@@ -1,0 +1,60 @@
+import { getSvgPath } from "figma-squircle";
+import type { CSSProperties } from "react";
+import { useMemo } from "react";
+
+import { useElementSize } from "./use-element-size";
+
+export interface SquircleOptions {
+  cornerSmoothing?: number;
+  cornerRadius?: number;
+
+  width?: number;
+  height?: number;
+
+  defaultWidth?: number;
+  defaultHeight?: number;
+}
+
+export function useSquircle({
+  cornerRadius,
+  cornerSmoothing = 0.6,
+  style,
+  width: requestedWidth,
+  height: requestedHeight,
+  defaultWidth,
+  defaultHeight,
+}: SquircleOptions & { style?: CSSProperties }) {
+  const [ref, { width, height }] = useElementSize<HTMLDivElement>({
+    defaultWidth,
+    defaultHeight,
+  });
+
+  const actualWidth = requestedWidth ?? width;
+  const actualHeight = requestedHeight ?? height;
+
+  const path = useMemo(() => {
+    if (actualWidth === 0 || actualHeight === 0) {
+      return "";
+    }
+    return getSvgPath({
+      width: actualWidth,
+      height: actualHeight,
+      cornerRadius,
+      cornerSmoothing,
+    });
+  }, [actualWidth, actualHeight, cornerRadius, cornerSmoothing]);
+
+  return {
+    ref,
+    elementProps: {
+      "data-squircle": cornerRadius,
+      style: {
+        ...style,
+        borderRadius: cornerRadius,
+        width: requestedWidth ?? defaultWidth,
+        height: requestedHeight ?? defaultHeight,
+        clipPath: `path('${path}')`,
+      },
+    },
+  };
+}

--- a/packages/squircle-element-react/tsup.config.js
+++ b/packages/squircle-element-react/tsup.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.tsx"],
+  entry: ["src/index.tsx", "src/base.tsx"],
   format: ["cjs", "esm"],
   dts: true,
   external: ["react"],

--- a/packages/squircle-element-react/tsup.config.js
+++ b/packages/squircle-element-react/tsup.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   external: ["react"],
   outExtension({ format }) {
     return {
-      js: format === "esm" ? ".mjs" : ".js",
+      js: format === "esm" ? ".mjs" : ".cjs",
     };
   },
 });

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -3,14 +3,19 @@
   "version": "0.1.0",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      },
       "default": "./dist/index.mjs"
     }
   },

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     lib: {
       entry: resolve(import.meta.dirname, "src/index.ts"),
       name: "SquircleJsVue",
-      fileName: (format) => (format === "es" ? "index.mjs" : "index.js"),
+      fileName: (format) => (format === "es" ? "index.mjs" : "index.cjs"),
       formats: ["es", "cjs"],
     },
     rollupOptions: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,9 @@ importers:
         specifier: 1.1.0
         version: 1.1.0
     devDependencies:
+      '@base-ui/react':
+        specifier: ^1.6.0
+        version: 1.6.0(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@squircle-js/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/typescript
@@ -561,6 +564,10 @@ packages:
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -572,6 +579,33 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@biomejs/biome@2.3.14':
     resolution: {integrity: sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA==}
@@ -1021,8 +1055,14 @@ packages:
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
   '@floating-ui/dom@1.7.5':
     resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
   '@floating-ui/react-dom@2.1.7':
     resolution: {integrity: sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==}
@@ -1030,8 +1070,17 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@futurebase/feedback@0.1.2':
     resolution: {integrity: sha512-0uxOye3DZ5J3CTkR/NjdXILPOohajYeLqIvIXutU1q7tchD5ob+gkaqLc1wvYVkwOqoFliVceqGKJOnv5SYkBw==}
@@ -2609,6 +2658,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/speed-insights@1.3.1':
     resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
@@ -4491,6 +4541,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -4966,6 +5019,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vfile-matter@5.0.1:
     resolution: {integrity: sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==}
 
@@ -5375,6 +5433,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -5397,6 +5457,29 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@base-ui/react@1.6.0(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@floating-ui/utils': 0.2.12
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      use-sync-external-store: 1.6.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.12
+
+  '@base-ui/utils@0.3.1(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.12
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.12
 
   '@biomejs/biome@2.3.14':
     optionalDependencies:
@@ -5787,10 +5870,19 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/dom@1.7.5':
     dependencies:
       '@floating-ui/core': 1.7.4
       '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
 
   '@floating-ui/react-dom@2.1.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -5798,7 +5890,15 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
+  '@floating-ui/react-dom@2.1.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
   '@floating-ui/utils@0.2.10': {}
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@futurebase/feedback@0.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.3)':
     dependencies:
@@ -9465,6 +9565,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  reselect@5.2.0: {}
+
   resolve-from@5.0.0: {}
 
   resolve@1.22.11:
@@ -10002,6 +10104,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.12
+
+  use-sync-external-store@1.6.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
 
   vfile-matter@5.0.1:
     dependencies:


### PR DESCRIPTION
Hey! This adds a Base UI-compatible entry point for `@squircle-js/react`.

> [!IMPORTANT]
> This PR is stacked on and depends on #38:
>
> #38 provides the conditional package exports and corrected ESM/CJS output that the new `/base` entry builds on. It should be merged first. Once it lands, this PR will contain only the Base UI integration commit.

## What changed

- Add `@squircle-js/react/base`
- Use Base UI's `useRender` API instead of the Radix-style `asChild` API
- Support both element and callback forms of the `render` prop
- Merge the forwarded ref with the internal size observer ref
- Extract the shared squircle measurement and path generation logic
- Keep the existing `@squircle-js/react` entry point behavior unchanged
- Declare `@base-ui/react` as an optional peer dependency
- Export ESM, CJS, and their corresponding type declarations
- Add a minor changeset

## Usage

```tsx
import { Squircle } from "@squircle-js/react/base";

<Squircle
  cornerRadius={20}
  cornerSmoothing={0.6}
  render={<button type="button" />}
>
  Click me
</Squircle>;

This keeps Base UI out of the existing entry point for consumers who do not use it.